### PR TITLE
Fix the EXIFAnalyzer spec

### DIFF
--- a/app/lib/exif_analyzer.rb
+++ b/app/lib/exif_analyzer.rb
@@ -13,9 +13,9 @@ class EXIFAnalyzer
       end
 
       if gps = exif.fields[:gps]
-        meta[:latitude] = gps.fields[:gps_latitude].to_f
-        meta[:longitude] = gps.fields[:gps_longitude].to_f
-        meta[:altitude] = gps.fields[:gps_altitude].to_f
+        meta[:latitude] = (gps.fields[:gps_latitude].nil? ? Float::NAN : gps.fields[:gps_latitude].to_f)
+        meta[:longitude] = (gps.fields[:gps_longitude].nil? ? Float::NAN : gps.fields[:gps_longitude].to_f)
+        meta[:altitude] = (gps.fields[:gps_altitude].nil? ? Float::NAN : gps.fields[:gps_altitude].to_f)
       end
       meta[:dump] = exif.fields.to_h if debug
     end

--- a/config/initializers/exifr.rb
+++ b/config/initializers/exifr.rb
@@ -1,3 +1,6 @@
+require 'exifr'
 require 'exifr/tiff'
 
 EXIFR::TIFF.mktime_proc = proc{ |*args| Time.zone.local(*args) }
+
+EXIFR.logger = Rails.logger


### PR DESCRIPTION
If EXIFR returns a nil value for GPS coordinates, Ruby will happily `to_f`
that to a 0.0f value. We need to actually check whether the value is nil
explicitly (or change our downstreams assumptions).

This also initializes the EXIFR logger to the Rails logger so we don’t
get stray STDERR output.