### PR TITLE
Add Admin::ExportsController to fix 404 in admin area

### DIFF
--- a/app/controllers/admin/exports_controller.rb
+++ b/app/controllers/admin/exports_controller.rb
@@ -1,0 +1,21 @@
+module Admin
+  class ExportsController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # you can overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = Authorization.
+    #     page(params[:page]).
+    #     per(10)
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   Authorization.find_by!(slug: param)
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end


### PR DESCRIPTION
Admin::ExportsController existierte nicht, Exports wurde aber im Admin-
UI angezeigt. Ich weiß nicht, wie sinnvoll es ist, Exports überhaupt
administrierbar zu haben, aber something’s got to give :D