### PR TITLE
Explicitly mention house number for user street attribute

### DIFF
--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -43,7 +43,7 @@ de:
         address: 'Anschrift'
         email: 'E-Mail'
         phone: 'Telefon'
-        street: 'Straße'
+        street: 'Straße & Hausnummer'
         appendix: 'Adresszusatz'
         zip: 'PLZ'
         city: 'Stadt'


### PR DESCRIPTION
This is something I noticed while signing up myself:

As the sign up form already mentions, the address needs to be 'ladungsfähig', so the house number is most likely very relevant. : ) It is noticable in the placeholder already, but that one disappears once the user clicks into the form field. Adding it to the form label makes it a bit more bullet proof in my opinion.

![image](https://user-images.githubusercontent.com/866318/97780237-be29ac80-1b83-11eb-95c4-b170940b3ff6.png)

