### PR TITLE
Add "Brixton" to car manufacturers

### DIFF
--- a/config/data/cars.json
+++ b/config/data/cars.json
@@ -1348,5 +1348,9 @@
       "Fortwo coupé",
       "Roadster"
     ]
+  },
+  {
+    "brand": "Brixton",
+    "models": []
   }
 ]


### PR DESCRIPTION
This adds [Brixton motorcycles](https://www.brixton-motorcycles.com) to the list of manufacturers.