### PR TITLE
fix #546: use gender-neutral phrases

### DIFF
--- a/app/lib/violation_generator.rb
+++ b/app/lib/violation_generator.rb
@@ -16,9 +16,7 @@ class ViolationGenerator
 
       document.move_down(50)
       document.text(
-        "Sehr geehrte Verkehrsteilnehmerin,
-        sehr geehrter Verkehrsteilnehmer,
-
+        "Sehr geehrte Verkehrsteilnehmer:innen,
 
         es wurde festgestellt, dass Sie gegen Verkehrsvorschriften verstoßen haben.
 

--- a/app/lib/violation_generator.rb
+++ b/app/lib/violation_generator.rb
@@ -18,6 +18,7 @@ class ViolationGenerator
       document.text(
         "Sehr geehrte Verkehrsteilnehmer:innen,
 
+
         es wurde festgestellt, dass Sie gegen Verkehrsvorschriften verstoßen haben.
 
         In Kürze werden Sie (ggf. der Halter) einen Bescheid mit weiteren Einzelheiten erhalten und haben dann die Gelegenheit, sich zum Sachverhalt zu äußern. Nutzen Sie hierfür dann gerne auch die Möglichkeit der Online-Anhörung.

--- a/app/views/notice_mailer/_header.text.erb
+++ b/app/views/notice_mailer/_header.text.erb
@@ -1,4 +1,4 @@
-Sehr geehrte Damen und Herren,
+Sehr geehrte Menschen,
 
 
 hiermit zeige ich, mit der Bitte um Weiterverfolgung, folgende Verkehrsordnungswidrigkeit an:

--- a/app/views/notice_mailer/charge.text.erb
+++ b/app/views/notice_mailer/charge.text.erb
@@ -1,4 +1,4 @@
-Sehr geehrte Damen und Herren,
+Sehr geehrte Menschen,
 
 
 <% if @send_via_pdf %>


### PR DESCRIPTION
PS: I used GitHub's web UI to rapidly draft this PR. I suggest to squash the commits when merging (also using [GitHub's web UI](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges)) and use an overall more meaningful commit messages (e.g., `fix #546: use gender-neutral phrases`).