### PR TITLE
Add Nio as car manufacturer

### DIFF
--- a/config/data/cars.json
+++ b/config/data/cars.json
@@ -1,5 +1,13 @@
 [
   {
+    "brand": "Nio",
+    "models": [
+      "ET7",
+      "ET5",
+      "EL7"
+    ]
+  },
+  {
     "brand": "Lincoln",
     "models": []
   },


### PR DESCRIPTION
Does it actually make sense to list models? Does this help with the search for the manufacturer or what is this information used for?
Regarding the content: Nio just startet the [rollout in Germany](https://ecomento.de/2022/10/18/nio-et7-auslieferungsstart-in-deutschland/)