### PR TITLE
fix(map): open popup on safari/macos

### DIFF
--- a/app/javascript/src/maps.js
+++ b/app/javascript/src/maps.js
@@ -34,7 +34,7 @@ function mapHTML(notice) {
 }
 
 function initMap(canvas, coords, zoom = 13) {
-  const map = L.map(canvas).setView(coords, zoom);
+  const map = L.map(canvas, {tab: L.Browser.safari && L.Browser.mobile}).setView(coords, zoom);
 
   L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution:


### PR DESCRIPTION
Problembeschreibung:
- Als Wegli Benutzer möchte ich die weg-li Karte im Safari Browser unter MacOS verwenden.

Erwartetes Verhalten: 
- Bei Klick auf einen Marker öffnet sich ein Popup mit Details.

Tatsächliches Verhalten: 
- Bei Klick auf einen Marker passiert nichts.

Laut folgendem Kommentar kann in der verwendeten leaflet version 1.7.1 per option parameter das Verhalten geändert werden: [Leaflet/Leaflet#7266 (comment)](https://github.com/Leaflet/Leaflet/issues/7266#issuecomment-793626176)

