### PR TITLE
Make full dropdown inside table visible

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -134,7 +134,7 @@ select {
 }
 
 .table-padding {
-  padding-bottom: 100px;
+  padding-bottom: 180px;
 }
 
 .form-dropdown {


### PR DESCRIPTION
With only one entry in the table the table padding of 100px is not enough.