### PR TITLE
feat(ci): run database preparation in ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,3 +68,31 @@ jobs:
           RAILS_ENV: test
           RSPEC_RETRY_RETRY_COUNT: 3
         run: bundle exec rake
+  setup:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgis/postgis:11-2.5
+        env:
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: weg-li_test
+        ports: ["5432:5432"]
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          cache: yarn
+          node-version: 18
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Install PostgreSQL 11 client
+        run: sudo apt-get update && sudo apt-get install postgresql postgresql-contrib libpq-dev --fix-missing
+      - run: bundle install
+      - run: yarn
+      - name: Prepare database
+        env:
+          PGHOST: localhost
+          PGPASSWORD: password
+        run: script/setup

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ config/data/opengeodb.csv
 yarn-debug.log*
 .yarn-integrity
 /bkat/TBKAT.DAT
+.vscode/
+public/assets/

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ createuser -s postgres # create general purpose postgres user
 brew install imagemagick # image-processing
 
 # project setup
-bin/setup
+script/setup
 ```
 
 ```bash

--- a/yarn.lock
+++ b/yarn.lock
@@ -6322,6 +6322,11 @@ prepend-http@^1.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prettier@^2.8.1:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"


### PR DESCRIPTION
In order to always allow new contributors to get the project running, `bin/setup`  needs to
be able to succesfully run in a properly set up environment. Since part of this script
is `bin/rails db:prepare`, which is currenlty failing, this new ci check functions
as a regression test, once the issue is repaired. Other parts of `bin/setup`, like
installation of the gems and npm packages is already part of the github actions
bootstrapping and so we cannot / should not run the whole `bin/setup` script.

fix #697 