### PR TITLE
Release API-Version 1.1.0

### DIFF
--- a/app/controllers/apidocs_controller.rb
+++ b/app/controllers/apidocs_controller.rb
@@ -12,7 +12,7 @@ class ApidocsController < ActionController::Base
     end
     security { key :api_key, [] }
     info do
-      key :version, "1.0.0"
+      key :version, "1.1.0"
       key :title, "weg.li API Docs"
       key :description,
           "


### PR DESCRIPTION
Durch die neusten Commits gab es an der API die folgende Änderungen:

- Neuer Endpoint `/charges` (757752602a124822144321ec408c60c13edee15a)
- Neuer Endpoint `/districts` (757752602a124822144321ec408c60c13edee15a)
- Neuer Endpoint `/charges/{tbnr}` (6dbae2bec7aa54bf17e61c31bf629e1a17a4676f)
- Neuer Endpoint `/districts/{zip}` (6dbae2bec7aa54bf17e61c31bf629e1a17a4676f)
- Neuer Endpoint `/exports` (8fee1a2c7611f5761de7625b29071608be3bcf62)
- Neuer Endpoint `/exports/public` (8fee1a2c7611f5761de7625b29071608be3bcf62)

Hierbei handelt es sich um abwärtskompatible Änderungen. Ich schlage daher vor, dass die API-Version auf `1.1.0` hochgesetzt wird.