### PR TITLE
add OSM to privacy policy (#860)

### DIFF
--- a/app/views/application/_privacy.html.erb
+++ b/app/views/application/_privacy.html.erb
@@ -16,6 +16,7 @@
   <li><a class="index-link" href="#m225">Bereitstellung des Onlineangebotes und Webhosting</a></li>
   <li><a class="index-link" href="#m367">Registrierung, Anmeldung und Nutzerkonto</a></li>
   <li><a class="index-link" href="#m451">Single-Sign-On-Anmeldung</a></li>
+  <li><a class="index-link" href="#m500">Einbindung von OpenStreetMap</a></li>
   <li><a class="index-link" href="#m12">Löschung von Daten</a></li>
   <li><a class="index-link" href="#m15">Änderung und Aktualisierung der Datenschutzerklärung</a></li>
   <li><a class="index-link" href="#m10">Rechte der betroffenen Personen</a></li>
@@ -135,6 +136,19 @@
   <li><strong>Google Single-Sign-On:</strong> Authentifizierungsdienst; Dienstanbieter: Google Ireland Limited, Gordon House, Barrow Street, Dublin 4, Irland, Mutterunternehmen: Google LLC, 1600 Amphitheatre Parkway, Mountain View, CA 94043, USA; Website: <a href="https://www.google.de" target="_blank">https://www.google.de</a>; Datenschutzerklärung: <a href="https://policies.google.com/privacy" target="_blank">https://policies.google.com/privacy</a>; Widerspruchsmöglichkeit (Opt-Out): Einstellungen für die Darstellung von Werbeeinblendungen: <a href="https://adssettings.google.com/authenticated" target="_blank">https://adssettings.google.com/authenticated</a>.</li>
   <li><strong>OpenID Single-Sign-On:</strong> Authentifizierungsdienst; Dienstanbieter: OpenID Foundation, 2400 Camino Ramon, Suite 375, San Ramon, CA 94583, USA; Website: <a href="https://openid.net" target="_blank">https://openid.net</a>; Datenschutzerklärung: <a href="https://openid.net/foundation/policies/" target="_blank">https://openid.net/foundation/policies/</a>.</li>
   <li><strong>Twitter Single-Sign-On:</strong> Authentifizierungsdienst; Dienstanbieter: Twitter International Company, One Cumberland Place, Fenian Street, Dublin 2 D02 AX07, Irland, Mutterunternehmen: Twitter Inc., 1355 Market Street, Suite 900, San Francisco, CA 94103, USA; Website: <a href="https://twitter.com" target="_blank">https://twitter.com</a>; Datenschutzerklärung: <a href="https://twitter.com/de/privacy" target="_blank">https://twitter.com/de/privacy</a>; Widerspruchsmöglichkeit (Opt-Out): <a href="https://twitter.com/personalization" target="_blank">https://twitter.com/personalization</a>.</li>
+</ul>
+<h2 id="m500">Einbindung von OpenStreetMap</h2>
+<p>Wir nutzen den Open-Source-Karten-Dienst "OpenStreetMaps" (= "OSM") zur Darstellung von Geo-Daten. Anbieter ist die Firma OpenStreetMap Foundation. OSM dient dazu, interaktive Karten auf unserer Webseite anzubieten, die Ihnen zeigen, wo sich beispielsweise Schwerpunkte für gemeldete Verstöße befinden. Zur Nutzung von OSM ist die Speicherung der IP-Adresse Ihres Endgerätes notwendig, außerdem wird das Kartenmaterial von einem externen Server geladen.</p>
+<p>Die Nutzung von OSM erfolgt im Interesse einer ansprechenden Darstellung unserer Online-Angebote und an einer leichten Auffindbarkeit der von uns auf der Website angegebenen Orte; dies stellt ein berechtigtes Interesse im Sinne von Art. 6 Abs. 1 lit. f DSGVO dar (Berechtigtes Interesse an der Datenverarbeitung).</p>
+<ul class="m-elements">
+  <li><strong>Verarbeitete Datenarten:</strong> Nutzungsdaten (z.B. besuchte Webseiten, Interesse an Inhalten, Zugriffszeiten), Meta-/Kommunikationsdaten (z.B. Geräte-Informationen, IP-Adressen).</li>
+  <li><strong>Betroffene Personen:</strong> Nutzer (z.B. Webseitenbesucher, Nutzer von Onlinediensten).</li>
+  <li><strong>Zwecke der Verarbeitung:</strong> Darstellung von Karten zur Visualisierungszwecken.</li>
+  <li><strong>Rechtsgrundlagen:</strong> Berechtigtes Interesse im Sinne von Art. 6 Abs. 1 lit. f DSGVO.</li>
+</ul>
+<p><strong>Weitere Informationen zum Diensteanbieter:</strong></p>
+<ul class="m-elements">
+  <li><strong>OpenStreetMap:</strong> OpenStreetMap Foundation CLG, 132 Maney Hill Road, Sutton Coldfield, West Midlands, B72 1JU, United Kingdom; Website: <a href="https://www.openstreetmap.org" target="_blank">https://www.openstreetmap.org</a>; Datenschutzerklärung: <a href="https://wiki.osmfoundation.org/wiki/Privacy_Policy" target="_blank">https://wiki.osmfoundation.org/wiki/Privacy_Policy</a>.</li>
 </ul>
 <h2 id="m12">Löschung von Daten</h2>
 <p>Die von uns verarbeiteten Daten werden nach Maßgabe der gesetzlichen Vorgaben gelöscht, sobald deren zur Verarbeitung erlaubten Einwilligungen widerrufen werden oder sonstige Erlaubnisse entfallen (z.B., wenn der Zweck der Verarbeitung dieser Daten entfallen ist oder sie für den Zweck nicht erforderlich sind).</p>


### PR DESCRIPTION
Ein Entwurf für eine angepasste Datenschutzerklärung (Beispiel: BLE: https://www.ble.de/DE/Service/Datenschutz/Datenschutz.html), die die Nutzung von OSM berücksichtigt.
Ich halte es für zweifelhaft, ob der Verweis auf Art. 6 (1) lit. f als Verarbeitungsgrundlage ausreicht. Eigentlich muss aktiv die Einwilligung der Nutzenden abgefragt werden. Dies erfordert dann auch, dass die Karten nicht beim Seitenaufruf geladen werden, sondern erst, nachdem die Nutzenden die Einwilligung erteilt haben. Eine Lösung via Javascript wäre denkbar.

Weitere Diskussion in #860 .