### PR TITLE
feat(api): add compact TBNR charge matrix endpoint

### DIFF
--- a/app/controllers/api/charges_controller.rb
+++ b/app/controllers/api/charges_controller.rb
@@ -50,4 +50,14 @@ class Api::ChargesController < Api::ApplicationController
   def show
     render json: Charge.active.from_param(params[:tbnr] || params[:id]).as_api_response(:public_beta)
   end
+
+  def compact
+    tsv_path = Rails.root.join("bkat/data/charges_compact.tsv")
+    legend_path = Rails.root.join("bkat/data/charges_compact_legend.txt")
+
+    legend = File.read(legend_path)
+    tsv = File.read(tsv_path)
+
+    render plain: "#{legend}\n#{tsv}", content_type: "text/tab-separated-values"
+  end
 end

--- a/bkat/data/charges_compact.tsv
+++ b/bkat/data/charges_compact.tsv
@@ -1,0 +1,93 @@
+location	p	p_beh	p_gef	p_unf	p_30m	p_1h	p_beh_1h	p_2h	p_3h	p_beh_3h	p_gef_3h	p_unf_3h	h	h_beh	h_gef	h_unf	u	u_30m	u_1h	u_2h	u_3h
+Abs. Haltverbot Z283	141312	141313				141314	141315						141310	141311							
+Allg. Behinderung		101060																			
+Anhänger >2t Wohngebiet	112397																				
+Anhänger o. Zugfzg >2Wo	112398																				
+Autobahn/Kraftfahrstr	118704		118705	118706									118178	118012							
+Behindertenparkplatz	142278																				
+Beschränkung Z262ff	141082	141583							141584												
+Bewohnerparkplatz	142252	142253							142254	142255											
+Bordsteinabsenkung	112372	112373							112374	112375											
+Bushaltestelle <15m	141402	141818	141819	141820					141821	141822	141823	141824									
+Bussonderfahrstreifen	141125	141828	141829	141830					141831	141832	141833	141834	141120	141825	141826	141827					
+Carsharing-Parkplatz	142290																				
+E-Fahrzeug-Parkplatz	142284																				
+Ein-/Ausfädelungsstr.													112120	112121							
+Einbahnstr. Gegenrichtung	112076																				
+Eingeschr. Haltverbot Bewohner	141392	141393				141394	141395														
+Eingeschr. Haltverbot Z286	141322	141323				141324	141325														
+Eingeschr. Haltverbot Zone	141118	141119				141121	141122														
+Enge Stelle Restfahrbahn	112600																				
+Enge/unübers. Stelle	112102	112103				112104	112105						112100	112101							
+Fahrradstraße	141124	141525	141528	141529		141526	141527						141020	141021	141522	141523					
+Fahrstreifenbegr. <3m	141412	141413							141414	141415											
+Feuerwehr	141056	141518											141050	141051							
+Fußgängerfurt Lichtzeichen		101048																			
+Fußgängerüberweg	141292	141293				141294	141295						141290	141291							
+Fußgängerüberweg <5m	141302	141303				141304	141305						141300	141301							
+Geh+Radweg	141194	141795	141798	141799		141796	141797		141786				141737	141091	141592	141593					
+Gehweg	112454	112655	112658	112659		112656	112657						112050	112051	112552	112553					
+Gehweg >2,8t Markierung	141042	141043				141044	141045														
+Gehweg Schachtdeckel	112322	112323							112324	112325											
+Gehweg Z315 >2,8t	142212	142213							142214	142215											
+Gehweg Z315 Aufstellung	142222	142223							142224	142225											
+Gehweg Z315 Einbahnstr.	112494	112695	112698	112699		112696	112697														
+Gehweg Z315 Zeitüberschr	142232	142233							142234	142235											
+Gehweg Z315 Zusatzz. verboten	142202	142203							142204	142205											
+Gehweg Z315 falsche Seite	112484	112685	112688	112689		112686	112687														
+Gekennz. Parkflächen	141015	141018							112284	112285											
+Grenzmark. Bus-Haltverbot													141123	141622	141623	141624					
+Grenzmark. Haltest-Parkverbot	141421	141842	141843	141844					141845	141846	141847	141848									
+Grenzmark. Haltverbot	141352	141353				141354	141355						141350	141351							
+Grenzmark. Parkverbot	141026	141027							141028	141029											
+Grundstückseinfahrt	112292	112293							112294	112295											
+Haltverbot Zone Scheibe falsch	113260				113261	113262		113263	113264												
+Haltverbot Zone Zeitüberschr																	113220	113221	113222	113223	113224
+Haltverbot Zone o. Scheibe	113240				113241	113242		113243	113244												
+Kfz >7,5t Wohngebiet	112396																				
+Kreisverkehr	141432	141433				141434	141435						141430	141431							
+Kreuzung <5m hinter	112272	112273							112274	112275											
+Kreuzung <5m vor	112262	112263							112264	112265											
+Kreuzung <8m (Radweg)	112266	112267							112268	112269											
+Lichtzeichen <10m	137012	137013				137014	137015						137010	137011							
+Linke Fahrbahnseite	112042	112043				112044	112045						112040	112041							
+Links Fahrbahnbegr. Z295	141332	141333				141334	141335						141330	141331							
+Nicht platzsparend	112456																				
+Nicht rechter Rand	112062	112063				112064	112065						112060	112061							
+Nothalte-/Pannenbucht	142160												142154								
+Parklücke Vorrang	112446																				
+Parkraumzone Scheibe falsch	113350				113351	113352		113353	113354												
+Parkraumzone Zeitüberschr																	113330	113331	113332	113333	113334
+Parkraumzone o. Scheibe	113340				113341	113342		113343	113344												
+Parkscheinaut. n. lesbar	113150				113151	113152		113153	113154												
+Parkscheinaut. o. Schein	113140				113141	113142		113143	113144												
+Parkuhr Zeitüberschr																	113160	113161	113162	113163	113164
+Parkuhr abgelaufen	113100				113101	113102		113103	113104												
+Parkuhr defekt Scheibe falsch	113200				113201	113202		113203	113204												
+Parkuhr defekt o. Scheibe	113180				113181	113182		113183	113184												
+Radweg beschildert	141174	141775	141778	141779		141776	141777						141070	141071	141572	141573					
+Radweg unbeschildert	112474	112675	112678	112679		112676	112677						112070	112071	112572	112573					
+Reitweg	141442	141443				141444	141445						141030	141031							
+Richtungspfeile Z297	141342	141343				141344	141345						141340	141341							
+Scharfe Kurve	112112	112113				112114	112115						112110	112111							
+Scharfe Kurve Restfahrbahn	112606																				
+Schienenfahrzeug-Fahrraum	112428	112618											112426	112427							
+Schmale Fahrb. Grundst	112302	112303							112304	112305											
+Schutzstreifen Rad													142170	142671	142672	142673					
+Seitenstreifen	112020																				
+Sperrfläche Z298	141245																				
+Taxenstand	141382	141383				141384	141385						141380	141381							
+Umweltzone	141621																				
+Verkehrsber. Bereich	142103	142104							142106	142107											
+Verkehrsinsel/Grünstreifen	112030																				
+Verkehrsverbot Z250ff	141164	141865							141866												
+Verkehrsverbot Z257	141032	141533							141534												
+Vorfahrtsstr. außerorts	142242	142243							142244	142245											
+Vorfahrtszeichen <10m	141362	141363				141364	141365						141360	141361							
+Z314 Parkverbot	142262	142263							142264	142265											
+Z314/315 Scheibe falsch	113320				113321	113322		113323	113324												
+Z314/315 Zeitüberschr																	113280	113281	113282	113283	113284
+Z314/315 o. Scheibe	113300				113301	113302		113303	113304												
+Zuparken	101024																				
+Zweite Reihe	112464	112665	112668	112669									112460	112661	112662	112663					
+Zweite Reihe >15min	112666	112667																			

--- a/bkat/data/charges_compact_legend.txt
+++ b/bkat/data/charges_compact_legend.txt
@@ -1,0 +1,33 @@
+# Compact Parking Charges Matrix — Column Legend
+#
+# Each row = one parking location/situation
+# Each column = a severity/duration variant
+# Cell values = 6-digit TBNR codes (empty = no matching charge)
+#
+# Column naming: {action}_{severity}_{duration}
+#
+# Actions:
+#   p  = parked (parkten/stellten/benutzten/nahmen/ließen)
+#   h  = stopped (hielten)
+#   u  = exceeded time (überschritten)
+#
+# Severity suffixes:
+#   (none) = base offense
+#   _beh   = with obstruction (Behinderung)
+#   _gef   = with endangerment (Gefährdung)
+#   _unf   = with accident (Unfall)
+#
+# Duration suffixes:
+#   (none) = base / no duration qualifier
+#   _30m   = longer than 30 minutes
+#   _1h    = longer than 1 hour
+#   _2h    = longer than 2 hours
+#   _3h    = longer than 3 hours
+#
+# Examples:
+#   p       = parked (base)
+#   p_beh   = parked with obstruction
+#   p_1h    = parked longer than 1 hour
+#   p_beh_3h = parked longer than 3 hours with obstruction
+#   h_gef   = stopped with endangerment
+#   u_30m   = exceeded time by more than 30 minutes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   mount Rswag::Ui::Engine => "/api-docs"
   mount Sidekiq::Web => "/sidekiq", :constraints => AdminConstraint.new
@@ -47,11 +49,13 @@ Rails.application.routes.draw do
     resources :exports, only: [:index] do
       collection { get :public }
     end
-    resources :districts, only: [:index, :show]
-    resources :signs, only: [:index, :show]
-    resources :plates, only: [:index, :show]
-    resources :charges, only: [:index, :show]
-    resources :brands, only: [:index, :show]
+    resources :districts, only: %i[index show]
+    resources :signs, only: %i[index show]
+    resources :plates, only: %i[index show]
+    resources :charges, only: %i[index show] do
+      collection { get :compact }
+    end
+    resources :brands, only: %i[index show]
   end
 
   resources :replies
@@ -190,6 +194,6 @@ Rails.application.routes.draw do
   get "/422", to: "errors#unacceptable"
   get "/500", to: "errors#internal_error"
 
-  get "/ping", to: ->(env) { [200, { "Content-Type" => "text/html" }, ["pong"]] }
-  match '*path.php', via: :all, to: ->(_env) { [302, { 'Location' => 'https://www.weg.li/violation/' }, ['Scheiße geparkt? Parkt nicht auf unseren Wegen!']] }
+  get "/ping", to: ->(_env) { [200, { "Content-Type" => "text/html" }, ["pong"]] }
+  match "*path.php", via: :all, to: ->(_env) { [302, { "Location" => "https://www.weg.li/violation/" }, ["Scheiße geparkt? Parkt nicht auf unseren Wegen!"]] }
 end

--- a/lib/tasks/charges_compact.rake
+++ b/lib/tasks/charges_compact.rake
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+namespace :data do
+  desc "Generate compact parking charges TSV from TatbestandBE.csv"
+  task generate_compact_charges: :environment do
+    require "csv"
+
+    csv_path = Rails.root.join("bkat/data/TatbestandBE.csv")
+    out_path = Rails.root.join("bkat/data/charges_compact.tsv")
+
+    charges = []
+    CSV.foreach(csv_path, headers: true, quote_char: "'") do |row|
+      next unless row["hatKlassifizierung"] == "5"
+      next unless row["validTo"].to_s.strip.empty?
+
+      charges << { tbnr: row["TBNR"], desc: row["Tatbestandstext"], valid_from: row["validFrom"].to_s }
+    end
+
+    rows = {}
+    all_cols = {}
+    dropped = []
+
+    charges.each do |c|
+      l = compact_location(c[:desc])
+      ck = compact_col_key(c[:desc])
+      rows[l] ||= {}
+
+      if rows[l][ck]
+        existing = rows[l][ck]
+        newer = c[:valid_from] > existing[:valid_from] ||
+                (c[:valid_from] == existing[:valid_from] && c[:tbnr] > existing[:tbnr])
+        if newer
+          dropped << "#{l} [#{ck}]: kept #{c[:tbnr]}, dropped #{existing[:tbnr]}"
+          rows[l][ck] = { tbnr: c[:tbnr], valid_from: c[:valid_from] }
+        else
+          dropped << "#{l} [#{ck}]: kept #{existing[:tbnr]}, dropped #{c[:tbnr]}"
+        end
+      else
+        rows[l][ck] = { tbnr: c[:tbnr], valid_from: c[:valid_from] }
+      end
+      all_cols[ck] = true
+    end
+
+    col_order = %w[
+      p p_beh p_gef p_unf
+      p_30m p_1h p_beh_1h p_gef_1h p_unf_1h
+      p_2h p_3h p_beh_3h p_gef_3h p_unf_3h
+      h h_beh h_gef h_unf
+      u u_30m u_1h u_2h u_3h
+    ]
+    used_cols = col_order.select { |c| all_cols[c] }
+
+    lines = ["location\t#{used_cols.join("\t")}"]
+    rows.sort_by { |k, _| k }.each do |l, cols|
+      vals = used_cols.map { |c| cols[c] ? cols[c][:tbnr] : "" }
+      lines << "#{l}\t#{vals.join("\t")}"
+    end
+
+    File.write(out_path, "#{lines.join("\n")}\n")
+
+    mapped = rows.values.flat_map { |cols| cols.values.map { |v| v[:tbnr] } }
+    puts "#{rows.size} locations, #{used_cols.size} columns, #{mapped.size} mapped"
+    puts "Columns: #{used_cols.join(', ')}"
+
+    if dropped.any?
+      puts "#{dropped.size} superseded TBNRs dropped (older duplicates)"
+    end
+  end
+end
+
+def compact_strip_qualifiers(desc)
+  d = desc.dup
+  d.gsub!(/,?\s*und behinderten \+\) dadurch Andere\.?/, "")
+  d.gsub!(/,?\s*und gefährdeten \+\) dadurch Andere\.?/, "")
+  d.gsub!(/,?\s*Es kam zum Unfall\.?/, "")
+  d.gsub!(/\s*mit Behinderung\.?/, "")
+  d.gsub!(/\s*länger als 3 Stunden/, "")
+  d.gsub!(/\s*-?\s*länger als 2 Stunden/, "")
+  d.gsub!(/\s*länger als eine Stunde/, "")
+  d.gsub!(/\s*länger als 1 Stunde/, "")
+  d.gsub!(/\s*-?\s*länger als 30 Minuten/, "")
+  d.gsub!(/, wodurch Andere behindert \+\) wurden\.?/, "")
+  d.gsub!(/^Sie (parkten|hielten|überschritten|stellten|benutzten|nahmen|ließen)\s*/, "")
+  d.strip.gsub(/\.\z/, "")
+end
+
+def compact_col_key(desc)
+  act = case desc
+        when /^Sie (parkten|stellten|benutzten|nahmen|ließen)/ then "p"
+        when /^Sie hielten/ then "h"
+        when /^Sie überschritten/ then "u"
+        else "p" # rubocop:disable Lint/DuplicateBranch -- default to parking
+        end
+  sev = case desc
+        when /Unfall/ then "_unf"
+        when /gefährdeten/ then "_gef"
+        when /behinderten|Behinderung|wodurch Andere behindert/ then "_beh"
+        else ""
+        end
+  dur = case desc
+        when /länger als 3 Stunden/ then "_3h"
+        when /länger als 2 Stunden/ then "_2h"
+        when /länger als (eine |1 )Stunde/ then "_1h"
+        when /länger als 30 Minuten/ then "_30m"
+        else ""
+        end
+  "#{act}#{sev}#{dur}"
+end
+
+def compact_location(desc)
+  n = compact_strip_qualifiers(desc)
+  case n
+  when /Schutzstreifen.*Radverkehr/ then "Schutzstreifen Rad"
+  when /Radfahrstreifen|Radweg.*Zeichen.*237/ then "Radweg beschildert"
+  when /unbeschilderten Radweg/ then "Radweg unbeschildert"
+  when /Fahrradstraße/ then "Fahrradstraße"
+  when /Geh- und Radweg/ then "Geh+Radweg"
+  when /Gehweg.*Parkflächenmarkierung.*2,8/ then "Gehweg >2,8t Markierung"
+  when /Gehweg.*Zeichen 315.*verboten/ then "Gehweg Z315 verboten"
+  when /Gehweg.*Zeichen 315.*2,8/ then "Gehweg Z315 >2,8t"
+  when /Gehweg.*Zeichen 315.*Aufstellungsart/ then "Gehweg Z315 Aufstellung"
+  when /Gehweg.*Zeichen 315.*Zeit/ then "Gehweg Z315 Zeitüberschr"
+  when /Gehweg.*Schachtdeckel/ then "Gehweg Schachtdeckel"
+  when /auf einem Fußgängerüberweg/ then "Fußgängerüberweg"
+  when /5 Metern? vor einem Fußgängerüberweg/ then "Fußgängerüberweg <5m"
+  when /Gehwegparken.*nicht auf dem rechten/ then "Gehweg Z315 falsche Seite"
+  when /Gehwegparken.*Einbahnstraße/ then "Gehweg Z315 Einbahnstr."
+  when /Zeichen 315 auf dem Gehweg.*Zusatzzeichen/ then "Gehweg Z315 Zusatzz. verboten"
+  when /verbotswidrig auf dem Gehweg/ then "Gehweg"
+  when /Gehweg/ then "Gehweg" # rubocop:disable Lint/DuplicateBranch -- catch-all for remaining Gehweg variants
+  when /absoluten Haltverbot/ then "Abs. Haltverbot Z283"
+  when /eingeschränkten Haltverbot.*Zone.*Höchstparkdauer/ then "Haltverbot Zone Zeitüberschr"
+  when /eingeschränkten Haltverbot.*Zone.*lesbar/ then "Haltverbot Zone o. Scheibe"
+  when /eingeschränkten Haltverbot.*Zone.*eingestellt/ then "Haltverbot Zone Scheibe falsch"
+  when /eingeschränkten Haltverbot.*Zone/ then "Eingeschr. Haltverbot Zone"
+  when /eingeschränkten Haltverbot.*Bewohner/ then "Eingeschr. Haltverbot Bewohner"
+  when /eingeschränkten Haltverbot|Haltverbot.*286/ then "Eingeschr. Haltverbot Z286"
+  when /Grenzmarkierung.*Haltverbot.*Bussonder/ then "Grenzmark. Bus-Haltverbot"
+  when /Grenzmarkierung.*Parkverbot.*Haltestelle/ then "Grenzmark. Haltest-Parkverbot"
+  when /Grenzmarkierung.*Haltverbot/ then "Grenzmark. Haltverbot"
+  when /Grenzmarkierung.*Parkverbot/ then "Grenzmark. Parkverbot"
+  when /Bussonderfahrstreifen/ then "Bussonderfahrstreifen"
+  when /15 Meter.*Haltestellenschild/ then "Bushaltestelle <15m"
+  when /Taxenstand/ then "Taxenstand"
+  when /15 Minuten.*zweite.*Reihe/ then "Zweite Reihe >15min"
+  when /zweite.*Reihe/ then "Zweite Reihe"
+  when /Feuerwehr.*5 Meter/ then "Feuerwehr <5m"
+  when /Feuerwehr.*Zufahrt/ then "Feuerwehr Zufahrt"
+  when /Feuerwehr/ then "Feuerwehr"
+  when /schwerbehinderte|Rollstuhl/ then "Behindertenparkplatz"
+  when /Autobahn|Kraftfahrstraße/ then "Autobahn/Kraftfahrstr"
+  when /linken Fahrbahnseite|linken Seitenstreifen/ then "Linke Fahrbahnseite"
+  when /Seitenstreifen/ then "Seitenstreifen"
+  when /8 Meter.*Kreuzung.*Radweg/ then "Kreuzung <8m (Radweg)"
+  when /5 Meter.*vor.*Kreuzung/ then "Kreuzung <5m vor"
+  when /5 Meter.*hinter.*Kreuzung/ then "Kreuzung <5m hinter"
+  when /Bordsteinabsenkung/ then "Bordsteinabsenkung"
+  when /enge.*Restfahrbahn|unübersichtlich.*Restfahrbahn/ then "Enge Stelle Restfahrbahn"
+  when /enge|unübersichtlich/ then "Enge/unübers. Stelle"
+  when /schmale.*Grundstück/ then "Schmale Fahrb. Grundst"
+  when /scharfen Kurve.*Verkehrsfläche/ then "Scharfe Kurve Restfahrbahn"
+  when /scharfen Kurve/ then "Scharfe Kurve"
+  when /Bahnübergang/ then "Bahnübergang"
+  when /abgelaufenen Parkuhr/ then "Parkuhr abgelaufen"
+  when /Parkuhr.*Parkscheibe.*lesbar/ then "Parkuhr defekt o. Scheibe"
+  when /Parkuhr.*Parkscheibe.*eingestellt/ then "Parkuhr defekt Scheibe falsch"
+  when /Parkuhr.*zulässige/ then "Parkuhr Zeitüberschr"
+  when /Parkscheinautomat.*ohne gültigen/ then "Parkscheinaut. o. Schein"
+  when /Parkscheinautomat.*gut lesbar/ then "Parkscheinaut. n. lesbar"
+  when /Parkscheinautomat.*nicht funktionsfähig.*lesbar/ then "Parkscheinaut. defekt o. Scheibe"
+  when /Parkscheinautomat.*nicht funktionsfähig.*eingestellt/ then "Parkscheinaut. defekt Scheibe falsch"
+  when /Parkscheinautomat.*zulässige|Parkscheinautomaten die auf dem Parkschein angegebene/ then "Parkscheinaut. Zeitüberschr"
+  when /Parkraumbewirtschaftung.*Höchstparkdauer/ then "Parkraumzone Zeitüberschr"
+  when /Parkraumbewirtschaftung.*lesbar/ then "Parkraumzone o. Scheibe"
+  when /Parkraumbewirtschaftung.*eingestellt/ then "Parkraumzone Scheibe falsch"
+  when /Parkraumbewirtschaftung/ then "Parkraumzone"
+  when /Sonderparkplatz.*Bewohner/ then "Bewohnerparkplatz"
+  when /Zeichen.*314.*315.*Höchstparkdauer/ then "Z314/315 Zeitüberschr"
+  when /Zeichen.*314.*315.*lesbar/ then "Z314/315 o. Scheibe"
+  when /Zeichen.*314.*315.*eingestellt/ then "Z314/315 Scheibe falsch"
+  when /Parkplatz.*Zeichen 314.*verboten/ then "Z314 Parkverbot"
+  when /verkehrsberuhigt/ then "Verkehrsber. Bereich"
+  when /Kreisverkehr/ then "Kreisverkehr"
+  when /Grundstück/ then "Grundstückseinfahrt"
+  when /Fußgängerfurt.*Lichtzeichen/ then "Fußgängerfurt Lichtzeichen"
+  when /Lichtzeichen/ then "Lichtzeichen <10m"
+  when /Fahrstreifenbegrenzung|295.*296.*3 Met/ then "Fahrstreifenbegr. <3m"
+  when /Fahrbahnbegrenzung.*295/ then "Links Fahrbahnbegr. Z295"
+  when /Richtungspfeile|Zeichen 297/ then "Richtungspfeile Z297"
+  when /rechten Fahrbahnrand/ then "Nicht rechter Rand"
+  when /außerhalb.*Ortschaft.*Vorfahrt/ then "Vorfahrtsstr. außerorts"
+  when /Vorfahrt|Andreaskreuz/ then "Vorfahrtszeichen <10m"
+  when /Reitweg/ then "Reitweg"
+  when /Zeichen <?257/ then "Verkehrsverbot Z257"
+  when /Zeichen <?25[0-3]|Zeichen <?255|Zeichen <?260/ then "Verkehrsverbot Z250ff"
+  when /Zeichen <?26[2-7]/ then "Beschränkung Z262ff"
+  when /elektrisch/ then "E-Fahrzeug-Parkplatz"
+  when /Carsharing/ then "Carsharing-Parkplatz"
+  when /Luftverunreinigung|Feinstaub/ then "Umweltzone"
+  when /Parkflächen/ then "Gekennz. Parkflächen"
+  when /nicht wegfahren/ then "Zuparken"
+  when /Andere$/ then "Allg. Behinderung"
+  when /Fußgängerfurt/ then "Fußgängerfurt"
+  when /Verkehrsinsel|Grünstreifen/ then "Verkehrsinsel/Grünstreifen"
+  when /Einbahnstraße.*entgegen/ then "Einbahnstr. Gegenrichtung"
+  when /Einfädelungsstreifen|Ausfädelungsstreifen/ then "Ein-/Ausfädelungsstr."
+  when /Kraftfahrzeug.*7,5.*Gebiet/ then "Kfz >7,5t Wohngebiet"
+  when /Kraftfahrzeuganhänger.*2 t.*Gebiet/ then "Anhänger >2t Wohngebiet"
+  when /Kraftfahrzeuganhänger.*ohne Zugfahrzeug/ then "Anhänger o. Zugfzg >2Wo"
+  when /Schienenfahrzeug/ then "Schienenfahrzeug-Fahrraum"
+  when /Vorrang.*Parklücke/ then "Parklücke Vorrang"
+  when /nicht Platz sparend/ then "Nicht platzsparend"
+  when /Sperrfläche.*298/ then "Sperrfläche Z298"
+  when /Nothalte|Pannenbucht/ then "Nothalte-/Pannenbucht"
+  else n[0..34]
+  end
+end


### PR DESCRIPTION
New `GET /api/charges/compact` endpoint that serves a compact parking charge matrix as TSV — 92 locations × 21 severity/duration columns → 406 TBNRs in ~2K tokens. Designed to add as context to a vision model to help it identify potential charges from photos.

The rake task `data:generate_compact_charges` regenerates the matrix from `TatbestandBE.csv`. Column legend is included as `#`-prefixed header lines in the API response.