### PR TITLE
Install `yaml-dev` before running `bundle install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add --update --no-cache \
   gcompat \
   alpine-sdk \
   imagemagick \
+  yaml-dev \
   nodejs \
   postgresql-client \
   postgresql-dev \


### PR DESCRIPTION
It's required by `psych`.

_Fixes #958._