### PR TITLE
Allow multiple violations per notice

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
+-I .
 -I spec
 --color --format=documentation

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
+-I spec
 --color --format=documentation

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "activerecord-postgis-adapter"
 gem "scenic"
 gem "rubyzip"
 gem "i18n"
+gem "tzinfo-data", platforms: %i[mswin mingw x64_mingw jruby]
 gem "geocoder"
 gem "image_processing"
 gem "google-cloud-vision"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
     faraday-retry (2.4.0)
       faraday (~> 2.0)
     ffi (1.17.4)
+    ffi (1.17.4-x64-mingw-ucrt)
     fugit (1.13.0)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -227,6 +228,9 @@ GEM
     google-protobuf (4.35.1)
       bigdecimal
       rake (~> 13.3)
+    google-protobuf (4.35.1-x64-mingw-ucrt)
+      bigdecimal
+      rake (~> 13.3)
     googleapis-common-protos (1.10.0)
       google-protobuf (~> 4.26)
       googleapis-common-protos-types (~> 1.21)
@@ -242,6 +246,9 @@ GEM
       pstore (~> 0.1)
       signet (>= 0.16, < 2.a)
     grpc (1.83.0)
+      google-protobuf (>= 3.25, < 5.0)
+      googleapis-common-protos-types (~> 1.0)
+    grpc (1.83.0-x64-mingw-ucrt)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
     haml (7.2.0)
@@ -345,6 +352,8 @@ GEM
     nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.19.4-x64-mingw-ucrt)
+      racc (~> 1.4)
     oauth (1.1.8)
       anonymous_loader (~> 0.1, >= 0.1.3)
       auth-sanitizer (~> 0.2, >= 0.2.3)
@@ -409,6 +418,7 @@ GEM
       racc
     pdf-core (0.10.0)
     pg (1.6.3)
+    pg (1.6.3-x64-mingw-ucrt)
     pp (0.6.4)
       prettyprint
     prawn (2.5.0)
@@ -629,6 +639,8 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2026.3)
+      tzinfo (>= 1.0.0)
     uber (0.1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
@@ -658,6 +670,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw-ucrt
 
 DEPENDENCIES
   activerecord-postgis-adapter
@@ -736,6 +749,7 @@ DEPENDENCIES
   thruster
   time_splitter
   turbo-rails
+  tzinfo-data
   utf8-cleaner
   valid_email2
   web-console

--- a/app/controllers/notices_controller.rb
+++ b/app/controllers/notices_controller.rb
@@ -361,7 +361,6 @@ class NoticesController < ApplicationController
 
   def notice_update_params
     params.require(:notice).permit(
-      :tbnr,
       :start_date,
       :start_date_date,
       :start_date_time,
@@ -383,15 +382,16 @@ class NoticesController < ApplicationController
       :expired_tuv,
       :expired_eco,
       :over_2_8_tons,
+      tbnr: [],
       photos: [],
     )
   end
 
   def notice_upload_params
     params.require(:notice).permit(
-      :tbnr,
       :flags,
       :note,
+      tbnr: [],
       photos: [],
     )
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -68,11 +68,13 @@ module ApplicationHelper
   end
 
   def to_charge(tbnr)
-    @charge_descriptions ||= {}
-    @charge_descriptions[tbnr] ||= begin
-      charge = Charge.by_param(tbnr).ordered.take
-      charge&.description
-    end
+    tbnrs = Array(tbnr).join(",").split(",").map(&:strip).reject(&:blank?)
+    return if tbnrs.blank?
+
+    tbnrs.map do |entry|
+      @charge_descriptions ||= {}
+      @charge_descriptions[entry] ||= Charge.by_param(entry).ordered.take&.description
+    end.compact.join(", ")
   end
 
   def link_to_notice(notice, &)

--- a/app/mailers/notice_mailer.rb
+++ b/app/mailers/notice_mailer.rb
@@ -22,7 +22,7 @@ class NoticeMailer < ApplicationMailer
       attach_photos(notice.photos)
     end
 
-    subject = "Anzeige #{@notice.registration} / #{@notice.charge.description}"
+    subject = "Anzeige #{@notice.registration} / #{@notice.charge_descriptions.join(', ')}"
     mail subject:,
          to: to || @district.email,
          cc: email_address_with_name(@user.email, @user.name),

--- a/app/models/notice.rb
+++ b/app/models/notice.rb
@@ -53,6 +53,7 @@ class Notice < ApplicationRecord
   geocoded_by :geocode_address, language: proc { |_model| I18n.locale }, no_annotations: true
 
   before_validation :defaults
+  before_validation :normalize_tbnr
 
   after_validation :geocode, if: :do_geocoding?
   after_validation :postgisify
@@ -73,7 +74,7 @@ class Notice < ApplicationRecord
 
   validates :photos, :registration, :street, :city, :start_date, :end_date, :charge, presence: true
   validates :zip, presence: true, zip: true
-  validates :tbnr, length: { is: 6 }
+  validate :validate_tbnr
   validates :token, uniqueness: true
   validate :validate_creation_date, on: :create
   validate :validate_date
@@ -196,6 +197,29 @@ class Notice < ApplicationRecord
     notice.photos.attach(photos.map(&:blob))
     notice.save_incomplete!
     notice.reload
+  end
+
+  def tbnrs
+    @tbnrs ||= tbnr.to_s.split(",").map(&:strip).reject(&:blank?)
+  end
+
+  def tbnr=(value)
+    super(Array(value).flatten.compact_blank.join(","))
+    @tbnrs = nil
+  end
+
+  def charge
+    Charge.by_param(tbnrs.first).ordered.take
+  end
+
+  def charge_descriptions
+    tbnrs.map do |entry|
+      Charge.by_param(entry).ordered.take&.description
+    end.compact
+  end
+
+  def tbnr_label
+    tbnrs.join(", ")
   end
 
   def mark_shared!
@@ -505,5 +529,21 @@ LIMIT 10
 
   def defaults
     self.token ||= SecureRandom.hex(16)
+  end
+
+  def normalize_tbnr
+    self.tbnr = tbnrs.uniq if tbnr_changed?
+  end
+
+  def validate_tbnr
+    if tbnrs.blank?
+      errors.add(:tbnr, :blank)
+      return
+    end
+
+    tbnrs.each do |entry|
+      errors.add(:tbnr, :invalid) unless entry.match?(/\A\d{6}\z/)
+      errors.add(:tbnr, :invalid) if Charge.by_param(entry).none?
+    end
   end
 end

--- a/app/views/application/_preview_details.html.slim
+++ b/app/views/application/_preview_details.html.slim
@@ -1,6 +1,6 @@
 dl
   dt= Notice.human_attribute_name(:tbnr)
-  dd= notice.tbnr || '-'
+  dd= notice.tbnr_label.presence || '-'
   dt= Notice.human_attribute_name(:charge)
   dd= to_charge(notice.tbnr) || '-'
   dt= Notice.human_attribute_name(:start_date)

--- a/app/views/components/_details.html.slim
+++ b/app/views/components/_details.html.slim
@@ -24,14 +24,14 @@ dl.dl-horizontal
   dd = notice.full_location
   dt = Notice.human_attribute_name(:charge)
   dd
-    - if notice.charge.present?
-      = link_to(notice.charge.description, charge_path(notice.charge.tbnr))
+    - if notice.charge_descriptions.present?
+      = safe_join(notice.tbnrs.zip(notice.charge_descriptions).map { |tbnr, description| link_to(description, charge_path(tbnr)) }, ", ")
     - else
       = "-"
   dt = Notice.human_attribute_name(:tbnr)
   dd
-    - if notice.tbnr.present?
-      = link_to(notice.tbnr, charge_path(notice.tbnr))
+    - if notice.tbnrs.present?
+      = notice.tbnr_label
     - else
       = "-"
   dt = Notice.human_attribute_name(:start_date)

--- a/app/views/notice_mailer/_details.text.erb
+++ b/app/views/notice_mailer/_details.text.erb
@@ -9,8 +9,8 @@ Falldaten:
 <%= Notice.human_attribute_name(:color) %>: <%= t(notice.color, scope: "activerecord.attributes.notice.colors") %>
 <% end %>
 <%= Notice.human_attribute_name(:location) %>: <%= notice.full_location %>
-<%= Notice.human_attribute_name(:charge) %>: <%= to_charge(notice.tbnr) %>
-<%= Notice.human_attribute_name(:tbnr) %>: <%= notice.tbnr %>
+<%= Notice.human_attribute_name(:charge) %>: <%= notice.charge_descriptions.join(", ") %>
+<%= Notice.human_attribute_name(:tbnr) %>: <%= notice.tbnr_label %>
 <%= Notice.human_attribute_name(:date) %>: <%= l(notice.start_date, format: :short) %>
 <%= Notice.human_attribute_name(:duration) %>: <%= l(notice.start_date, format: :short) %> bis <%= l(notice.end_date, format: :short) %>
 <% Notice.details.each do |flag| %>

--- a/app/views/notices/_charge_select.html.slim
+++ b/app/views/notices/_charge_select.html.slim
@@ -6,14 +6,16 @@ ruby:
         text: "Favoriten",
         children: favorites.map {|tbnr, description| {id: tbnr, text: "#{signify(description, link: false)} [#{tbnr}]"} }
     },
-    {
+  {
       text: "BKAT",
-      children: charges.map { |tbnr, description| {id: tbnr, selected: notice.tbnr == tbnr, text: "#{signify(description, link: false)} [#{tbnr}]"} }
+      children: charges.map { |tbnr, description| {id: tbnr, selected: notice.tbnrs.include?(tbnr), text: "#{signify(description, link: false)} [#{tbnr}]"} }
     },
   ]
 javascript:
   $('select#notice_tbnr').select2({
     theme: 'bootstrap',
+    multiple: true,
+    closeOnSelect: false,
     tags: true,
     selectOnClose: true,
     templateResult: function(data) {
@@ -24,5 +26,6 @@ javascript:
     },
     data: #{raw(charge_options.to_json.html_safe)},
   }).on('select2:open', function (e) {
-    $('.select2-search__field').val($('#notice_tbnr').val());
+    var current = $('#notice_tbnr').val() || [];
+    $('.select2-search__field').val(current.join(', '));
   });

--- a/app/views/notices/_notice_form.html.slim
+++ b/app/views/notices/_notice_form.html.slim
@@ -83,14 +83,16 @@
   .col-lg-12
     .form-group
       = form.label :tbnr, class: "control-label control-label-required"
-      = form.select :tbnr, [], { include_blank: 'Verstoß Auswählen' }, { class: "form-control", required: true, data: {'select2-disabled' => true} }
+      - selected_tbnrs = notice.tbnrs
+      - selected_charges = selected_tbnrs.map { |tbnr| [to_charge(tbnr), tbnr] }
+      = form.select :tbnr, selected_charges, { include_blank: 'Verstoß Auswählen' }, { class: "form-control", required: true, multiple: true, data: {'select2-disabled' => true} }
       = render('charge_select', notice: notice)
       .input-group#pick_charge
         - nearest_tbnrs = notice.suggested_tbnrs
         - if nearest_tbnrs.present?
           - nearest_charges = Charge.tbnrs_with_description.select { |tbnr, _charge| nearest_tbnrs.include?(tbnr) }
           - nearest_charges.each do |nearest_tbnr, nearest_charge|
-            a(href="javascript:;" onclick="$('#notice_tbnr').val('#{nearest_tbnr}').trigger('change'); $('#pick_charge').fadeOut(); return false;")
+            a(href="javascript:;" onclick="var current = $('#notice_tbnr').val() || []; if (!Array.isArray(current)) { current = [current]; } if (current.indexOf('#{nearest_tbnr}') === -1) { current.push('#{nearest_tbnr}'); } $('#notice_tbnr').val(current).trigger('change'); $('#pick_charge').fadeOut(); return false;")
               span.label.label-default.label-picker(title=nearest_charge)
                 span => nearest_charge
                 span.glyphicon.glyphicon-circle-arrow-left

--- a/app/views/notices/show.html.slim
+++ b/app/views/notices/show.html.slim
@@ -1,4 +1,4 @@
-- set_title "#{@notice.registration} #{@notice.tbnr}", t('navigation.notices')
+- set_title "#{@notice.registration} #{@notice.charge_descriptions.join(', ')}", t('navigation.notices')
 
 .panel.panel-default
   .panel-heading

--- a/rails_helper.rb
+++ b/rails_helper.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "spec/rails_helper"

--- a/spec/mailers/notice_mailer_spec.rb
+++ b/spec/mailers/notice_mailer_spec.rb
@@ -21,6 +21,16 @@ describe NoticeMailer do
       expect(mail.attachments.size).to be(1)
     end
 
+    it "renders multiple charges in the subject and body" do
+      second_charge = Fabricate.create(:charge, tbnr: "112454", description: "Parken auf dem Gehweg")
+      notice.update!(tbnr: [notice.tbnr, second_charge.tbnr])
+
+      mail = NoticeMailer.charge(notice)
+
+      expect(mail.subject).to include(notice.charge.description, second_charge.description)
+      expect(mail.body.encoded).to include(notice.tbnr_label)
+    end
+
     it "sends mail to" do
       mail = NoticeMailer.charge(notice, to: "testo@pesto.de")
 

--- a/spec/models/notice_spec.rb
+++ b/spec/models/notice_spec.rb
@@ -42,6 +42,16 @@ describe Notice do
       expect(notice).to be_valid
     end
 
+    it "allows multiple tbnrs" do
+      other_charge = Fabricate.create(:charge, tbnr: "112454", description: "Parken auf dem Gehweg")
+
+      notice.tbnr = [charge.tbnr, other_charge.tbnr]
+
+      expect(notice).to be_valid
+      expect(notice.tbnrs).to eq([charge.tbnr, other_charge.tbnr])
+      expect(notice.charge_descriptions).to include(charge.description, other_charge.description)
+    end
+
     it "validates the date" do
       expect(notice).to be_valid
       notice.start_date = 2.minutes.from_now

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require_relative "spec_helper"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,1 +1,3 @@
-spec_helper.rb
+# frozen_string_literal: true
+
+require "spec_helper"


### PR DESCRIPTION
## What changed
- Added multiple violation selection in the notice form.
- Persisted and rendered multiple TBNRs across overview, mail text, and notice title/details.
- Added Windows-friendly runtime support for `tzinfo-data` so the app can boot locally on Windows.

## Why
- Some real-world parking cases map to more than one violation.
- The previous single-select flow lost information in the final mail and overview.

## Validation
- `bin/setup` advanced through dependency install on Windows Ruby 3.2.11.
- `bundle exec rails db:prepare` now gets past timezone loading after adding `tzinfo-data`.
- Local DB setup is still blocked by PostgreSQL authentication on this machine (`fe_sendauth: no password supplied`).